### PR TITLE
RESTful api uri 단/복수 규칙 적용 내용 수정

### DIFF
--- a/src/main/java/com/apebble/askwatson/cafe/CafeController.java
+++ b/src/main/java/com/apebble/askwatson/cafe/CafeController.java
@@ -15,7 +15,7 @@ public class CafeController {
     private final ResponseService responseService;
 
     // 방탈출 카페 등록
-    @PostMapping(value="/admin/cafe")
+    @PostMapping(value="/admin/cafes")
     public SingleResponse<Cafe> createCafe(@ModelAttribute CafeParams params) {
         return responseService.getSingleResponse(cafeService.createCafe(params));
     }
@@ -27,19 +27,19 @@ public class CafeController {
     }
 
     // 방탈출 카페 단건 조회
-    @GetMapping(value = "/cafe/{cafeId}")
+    @GetMapping(value = "/cafes/{cafeId}")
     public SingleResponse<Cafe> getCafe(@PathVariable Long cafeId) {
         return responseService.getSingleResponse(cafeService.getOneCafe(cafeId));
     }
 
     // 방탈출 카페 수정
-    @PutMapping(value = "/cafe/{cafeId}")
+    @PutMapping(value = "/cafes/{cafeId}")
     public SingleResponse<Cafe> modifyCafe(@PathVariable Long cafeId, @ModelAttribute CafeParams params) {
         return responseService.getSingleResponse(cafeService.modifyCafe(cafeId, params));
     }
 
     // 방탈출 카페 삭제
-    @DeleteMapping(value = "/cafe/{cafeId}")
+    @DeleteMapping(value = "/cafes/{cafeId}")
     public CommonResponse deleteCafe(@PathVariable Long cafeId) {
         cafeService.deleteCafe(cafeId);
         return responseService.getSuccessResponse();

--- a/src/main/java/com/apebble/askwatson/faq/FaqController.java
+++ b/src/main/java/com/apebble/askwatson/faq/FaqController.java
@@ -15,7 +15,7 @@ public class FaqController {
     private final ResponseService responseService;
 
     // 자주묻는질문 등록
-    @PostMapping(value="/admin/faq")
+    @PostMapping(value="/admin/faqs")
     public SingleResponse<Faq> createFaq(@ModelAttribute FaqParams params) {
         return responseService.getSingleResponse(faqService.createFaq(params));
     }
@@ -27,19 +27,19 @@ public class FaqController {
     }
 
     // 자주묻는질문 단건 조회
-    @GetMapping(value = "/faq/{faqId}")
+    @GetMapping(value = "/faqs/{faqId}")
     public SingleResponse<Faq> getFaq(@PathVariable Long faqId) {
         return responseService.getSingleResponse(faqService.getOneFaq(faqId));
     }
 
     // 자주묻는질문 수정
-    @PutMapping(value = "/faq/{faqId}")
+    @PutMapping(value = "/faqs/{faqId}")
     public SingleResponse<Faq> modifyFaq(@PathVariable Long faqId, @ModelAttribute FaqParams params) {
         return responseService.getSingleResponse( faqService.modifyFaq(faqId, params));
     }
 
     // 자주묻는질문 삭제
-    @DeleteMapping(value = "/admin/faq/{faqId}")
+    @DeleteMapping(value = "/admin/faqs/{faqId}")
     public CommonResponse deleteCafe(@PathVariable Long faqId) {
         faqService.deleteFaq(faqId);
         return responseService.getSuccessResponse();

--- a/src/main/java/com/apebble/askwatson/notice/NoticeController.java
+++ b/src/main/java/com/apebble/askwatson/notice/NoticeController.java
@@ -16,7 +16,7 @@ public class NoticeController {
     private final ResponseService responseService;
 
     // 공지사항 등록
-    @PostMapping(value="/admin/notice")
+    @PostMapping(value="/admin/notices")
     public SingleResponse<Notice> createNotice(@ModelAttribute NoticeParams params) {
         return responseService.getSingleResponse(noticeService.createNotice(params));
     }
@@ -28,19 +28,19 @@ public class NoticeController {
     }
 
     // 공지사항 단건 조회
-    @GetMapping(value="/notice/{noticeId}")
+    @GetMapping(value="/notices/{noticeId}")
     public SingleResponse<Notice> getOneNotice(@PathVariable Long noticeId) {
         return responseService.getSingleResponse(noticeService.getOneNotice(noticeId));
     }
 
     // 공지사항 수정
-    @PutMapping(value = "/admin/notice/{noticeId}")
+    @PutMapping(value = "/admin/notices/{noticeId}")
     public SingleResponse<Notice> modifyNotice(@PathVariable Long noticeId, @ModelAttribute NoticeParams params) {
         return responseService.getSingleResponse(noticeService.modifyNotice(noticeId, params));
     }
 
     // 공지사항 삭제
-    @DeleteMapping(value = "/admin/notice/{noticeId}")
+    @DeleteMapping(value = "/admin/notices/{noticeId}")
     public CommonResponse deleteNotice(@PathVariable Long noticeId) {
         noticeService.deleteNotice(noticeId);
         return responseService.getSuccessResponse();

--- a/src/main/java/com/apebble/askwatson/theme/ThemeController.java
+++ b/src/main/java/com/apebble/askwatson/theme/ThemeController.java
@@ -13,7 +13,7 @@ public class ThemeController {
     private final ResponseService responseService;
 
     // 방탈출 테마 등록
-    @PostMapping(value="/admin/cafe/{cafeId}/theme")
+    @PostMapping(value="/admin/cafes/{cafeId}/themes")
     public SingleResponse<Theme> createTheme(@PathVariable Long cafeId, @ModelAttribute ThemeParams params) {
         return responseService.getSingleResponse(themeService.createTheme(cafeId, params));
     }


### PR DESCRIPTION
## 어떤 변경사항을 반영한 pr인가요?
[참고문서1](https://velog.io/@couchcoding/%EA%B0%9C%EB%B0%9C-%EC%B4%88%EB%B3%B4%EB%A5%BC-%EC%9C%84%ED%95%9C-RESTful-API-%EC%84%A4%EA%B3%84-%EA%B0%80%EC%9D%B4%EB%93%9C)
[참고문서2](https://blog.pumpkin-raccoon.com/115)

Collection : Document의 집합, DB에서 테이블이라 볼 수 있다.
Document : 문서 or 한 객체
Collection 리소스의 경우 복수형으로 표현하는 것이 일반적이라고 합니다! 단수형으로 사용되는 경우도 있지만 단/복수를 혼용해서 사용하는 방법은 지양한다고 합니다!!

## 리뷰 시 참고할 내용은 무엇인가요?

변경사항 확인 부탁드립니다!! @hanslelee 
