### PR TITLE
방탈출 카페, 테마 객체 등록 api

### DIFF
--- a/src/main/java/com/apebble/askwatson/cafe/Cafe.java
+++ b/src/main/java/com/apebble/askwatson/cafe/Cafe.java
@@ -36,6 +36,7 @@ public class Cafe extends BaseTime {
 
     private String address;                                     // 방탈출카페 주소
 
+    @Column(length = 400)
     private String imageUrl;                                    // 방탈출카페 이미지 url
 
     @Column(nullable = false, columnDefinition = "GEOMETRY")

--- a/src/main/java/com/apebble/askwatson/cafe/CafeController.java
+++ b/src/main/java/com/apebble/askwatson/cafe/CafeController.java
@@ -22,6 +22,12 @@ public class CafeController {
         return responseService.getSingleResponse(cafeService.createCafe(params));
     }
 
+    // 방탈출 카페 객체 등록
+    @PostMapping(value="/admin/cafes/new")
+    public SingleResponse<Long> createCafeObj() throws ParseException {
+        return responseService.getSingleResponse(cafeService.createCafeObj());
+    }
+
     // 방탈출 카페 전체 조회
     @GetMapping(value="/cafes")
     public PageResponse<CafeDto.Response> getCafes(

--- a/src/main/java/com/apebble/askwatson/cafe/CafeJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/cafe/CafeJpaRepository.java
@@ -16,5 +16,5 @@ public interface CafeJpaRepository extends JpaRepository<Cafe, Long> {
 
 
     @Query(value = "select c from Cafe c where :searchWord is null or (c.cafeName like %:searchWord% or c.address like %:searchWord%  or c.location.state like %:searchWord% or c.location.city like %:searchWord%)")
-    List<Cafe> findCafesBySearchWord(String searchWord);
+    List<Cafe> findCafesBySearchWord(@Param("searchWord") String searchWord);
 }

--- a/src/main/java/com/apebble/askwatson/cafe/CafeService.java
+++ b/src/main/java/com/apebble/askwatson/cafe/CafeService.java
@@ -45,6 +45,13 @@ public class CafeService {
         return convertToCafeDto(cafeJpaRepository.save(cafe));
     }
 
+    public Long createCafeObj() throws ParseException {
+        Cafe cafe = new Cafe();
+        cafe.setGeography(GeographyConverter.strToPoint(0.0, 0.0));
+
+        return cafeJpaRepository.save(cafe).getId();
+    }
+
     // 방탈출 카페 전체 조회
     public Page<CafeDto.Response> getCafes(CafeSearchOptions searchOptions, Pageable pageable) {
         Page<Cafe> cafeList;

--- a/src/main/java/com/apebble/askwatson/escapecomplete/EscapeCompleteJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/escapecomplete/EscapeCompleteJpaRepository.java
@@ -1,13 +1,14 @@
 package com.apebble.askwatson.escapecomplete;
 
+import com.apebble.askwatson.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface EscapeCompleteJpaRepository extends JpaRepository<EscapeComplete, Long> {
-    
     List<EscapeComplete> findByUserId(Long userId);
 
     EscapeComplete findByUserIdAndThemeId(Long userId, Long themeId);
 
+    int countByUser(User user);
 }

--- a/src/main/java/com/apebble/askwatson/faq/FaqJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/faq/FaqJpaRepository.java
@@ -2,10 +2,11 @@ package com.apebble.askwatson.faq;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface FaqJpaRepository extends JpaRepository<Faq, Long> {
     @Query(value = "select f from Faq f where :searchWord is null or (f.title like %:searchWord% or f.content like %:searchWord%)")
-    List<Faq> findFaqsBySearchWord(String searchWord);
+    List<Faq> findFaqsBySearchWord(@Param("searchWord") String searchWord);
 }

--- a/src/main/java/com/apebble/askwatson/notice/NoticeJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/notice/NoticeJpaRepository.java
@@ -2,11 +2,12 @@ package com.apebble.askwatson.notice;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface NoticeJpaRepository extends JpaRepository<Notice, Long> {
     @Query(value = "select n from Notice n where :searchWord is null or (n.title like %:searchWord% or n.content like %:searchWord%)")
-    List<Notice> findNoticesBySearchWord(String searchWord);
+    List<Notice> findNoticesBySearchWord(@Param("searchWord") String searchWord);
     
 }

--- a/src/main/java/com/apebble/askwatson/report/ReportJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/report/ReportJpaRepository.java
@@ -1,5 +1,6 @@
 package com.apebble.askwatson.report;
 
+import com.apebble.askwatson.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -13,4 +14,6 @@ public interface ReportJpaRepository extends JpaRepository<Report, Long> {
 
     @Query(value = "select r from Report r where r.handledYn =:handledYn and :searchWord is null or (r.reporter.userNickname like %:searchWord% or r.reportedUser.userNickname like %:searchWord% or r.content like %:searchWord% or r.review.content like %:searchWord% or r.review.theme.themeName like %:searchWord% or r.review.theme.cafe.cafeName like %:searchWord%)")
     List<Report> findReportsByHandledYnAndSearchWord(String searchWord, Boolean handledYn);
+
+    int countByReportedUser(User user);
 }

--- a/src/main/java/com/apebble/askwatson/report/ReportJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/report/ReportJpaRepository.java
@@ -3,6 +3,7 @@ package com.apebble.askwatson.report;
 import com.apebble.askwatson.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,10 +11,10 @@ public interface ReportJpaRepository extends JpaRepository<Report, Long> {
     List<Report> findByHandledYn(boolean handledYn);
 
     @Query(value = "select r from Report r where :searchWord is null or (r.reporter.userNickname like %:searchWord% or r.reportedUser.userNickname like %:searchWord% or r.content like %:searchWord% or r.review.content like %:searchWord% or r.review.theme.themeName like %:searchWord% or r.review.theme.cafe.cafeName like %:searchWord%)")
-    List<Report> findReportsBySearchWord(String searchWord);
+    List<Report> findReportsBySearchWord(@Param("searchWord") String searchWord);
 
     @Query(value = "select r from Report r where r.handledYn =:handledYn and :searchWord is null or (r.reporter.userNickname like %:searchWord% or r.reportedUser.userNickname like %:searchWord% or r.content like %:searchWord% or r.review.content like %:searchWord% or r.review.theme.themeName like %:searchWord% or r.review.theme.cafe.cafeName like %:searchWord%)")
-    List<Report> findReportsByHandledYnAndSearchWord(String searchWord, Boolean handledYn);
+    List<Report> findReportsByHandledYnAndSearchWord(@Param("searchWord") String searchWord, @Param("handledYn") Boolean handledYn);
 
     int countByReportedUser(User user);
 }

--- a/src/main/java/com/apebble/askwatson/review/ReviewJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/review/ReviewJpaRepository.java
@@ -7,8 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.apebble.askwatson.user.User;
 
 public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
-
     List<Review> findByUser(User user);
+
     List<Review> findByThemeId(Long themeId);
 
+    int countByUser(User user);
 }

--- a/src/main/java/com/apebble/askwatson/theme/Theme.java
+++ b/src/main/java/com/apebble/askwatson/theme/Theme.java
@@ -24,7 +24,7 @@ public class Theme extends BaseTime {
     @Column(length = 64)
     private String themeName;                       // 테마명
 
-    @Column(length = 100, nullable = false)
+    @Column(length = 1000, nullable = false)
     private String themeExplanation;                // 테마 설명
 
     @ManyToOne @JoinColumn(name = "category_id")
@@ -36,8 +36,10 @@ public class Theme extends BaseTime {
 
     private Integer price;                          // 가격
 
+    @Column(length = 400)
     private String reservationUrl;                  // 예약하기 url
 
+    @Column(length = 400)
     private String imageUrl;                        // 방탈출테마 이미지 url
 
     @Builder.Default @ColumnDefault("0")

--- a/src/main/java/com/apebble/askwatson/theme/ThemeController.java
+++ b/src/main/java/com/apebble/askwatson/theme/ThemeController.java
@@ -21,6 +21,12 @@ public class ThemeController {
         return responseService.getSingleResponse(themeService.createTheme(cafeId, params));
     }
 
+    // 방탈출 테마 객체 등록
+    @PostMapping(value="/admin/cafes/{cafeId}/themes/new")
+    public SingleResponse<Long> createThemeObj(@PathVariable Long cafeId) {
+        return responseService.getSingleResponse(themeService.createThemeObj(cafeId));
+    }
+
     // 테마 목록 전체 조회
     @GetMapping(value = "/themes")
     public PageResponse<ThemeDto.Response> getThemes(

--- a/src/main/java/com/apebble/askwatson/theme/ThemeJpaRepository.java
+++ b/src/main/java/com/apebble/askwatson/theme/ThemeJpaRepository.java
@@ -27,5 +27,5 @@ public interface ThemeJpaRepository extends JpaRepository<Theme, Long> {
     Page<Theme> findThemesByOptions(@Param("options") ThemeSearchOptions options, Pageable pageable);
 
     @Query(value = "select t from Theme t where :searchWord is null or (t.themeName like %:searchWord% or t.themeExplanation like %:searchWord%  or t.cafe.cafeName like %:searchWord% or t.cafe.address like %:searchWord% or t.cafe.location.state like %:searchWord% or t.cafe.location.city like %:searchWord% or t.category.categoryName like %:searchWord%)")
-    List<Theme> findThemesBySearchWord(String searchWord);
+    List<Theme> findThemesBySearchWord(@Param("searchWord") String searchWord);
 }

--- a/src/main/java/com/apebble/askwatson/theme/ThemeService.java
+++ b/src/main/java/com/apebble/askwatson/theme/ThemeService.java
@@ -49,6 +49,15 @@ public class ThemeService {
         return themeJpaRepository.save(theme);
     }
 
+    public Long createThemeObj(Long cafeId)  {
+        Cafe cafe = cafeJpaRepository.findById(cafeId).orElseThrow(CafeNotFoundException::new);
+        Theme theme = new Theme();
+        theme.setThemeExplanation("");
+        theme.setCafe(cafe);
+
+        return themeJpaRepository.save(theme).getId();
+    }
+
     // 카페별 테마 조회
     public List<Theme> getThemesByCafe(Long cafeId) {
         Cafe cafe = cafeJpaRepository.findById(cafeId).orElseThrow(CafeNotFoundException::new);

--- a/src/main/java/com/apebble/askwatson/user/UserController.java
+++ b/src/main/java/com/apebble/askwatson/user/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
 
     // 회원 전체 조회
     @GetMapping(value = "/admin/users")
-    public PageResponse<User> getAllUsers(@PageableDefault(size=20) Pageable pageable) {
+    public PageResponse<UserDto.Response> getAllUsers(@PageableDefault(size=20) Pageable pageable) {
         return responseService.getPageResponse(userService.getAllUsers(pageable));
     }
 

--- a/src/main/java/com/apebble/askwatson/user/UserDto.java
+++ b/src/main/java/com/apebble/askwatson/user/UserDto.java
@@ -17,7 +17,7 @@ public class UserDto {
         private int reportedCount;
         private int reviewCount;
         private int escapeCompleteCount;
-        private String signUpDt;
+        private String createdAt;
 
         public Response(User entity, int reportedCount, int reviewCount, int escapeCompleteCount) {
             this.id = entity.getId();

--- a/src/main/java/com/apebble/askwatson/user/UserDto.java
+++ b/src/main/java/com/apebble/askwatson/user/UserDto.java
@@ -29,7 +29,7 @@ public class UserDto {
             this.reportedCount = reportedCount;
             this.reviewCount = reviewCount;
             this.escapeCompleteCount = escapeCompleteCount;
-            this.signUpDt = entity.getCreatedAt().toString();
+            this.createdAt = entity.getCreatedAt().toString();
         }
     }
 }

--- a/src/main/java/com/apebble/askwatson/user/UserDto.java
+++ b/src/main/java/com/apebble/askwatson/user/UserDto.java
@@ -1,0 +1,35 @@
+package com.apebble.askwatson.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UserDto {
+
+    @Getter @Setter
+    public static class Response {
+        private Long id;
+        private String userNickname;
+        private String userPhoneNum;
+        private String userBirth;
+        private char userGender;
+        private Boolean marketingAgreeYn;
+        private int reportedCount;
+        private int reviewCount;
+        private int escapeCompleteCount;
+        private String signUpDt;
+
+        public Response(User entity, int reportedCount, int reviewCount, int escapeCompleteCount) {
+            this.id = entity.getId();
+            this.userNickname = entity.getUserNickname();
+            this.userPhoneNum = entity.getUserPhoneNum();
+            this.userBirth = entity.getUserBirth().toString();
+            this.userGender = entity.getUserGender();
+            this.marketingAgreeYn = entity.getMarketingAgreeYn();
+            this.reportedCount = reportedCount;
+            this.reviewCount = reviewCount;
+            this.escapeCompleteCount = escapeCompleteCount;
+            this.signUpDt = entity.getCreatedAt().toString();
+        }
+    }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -42,12 +42,33 @@ INSERT INTO category(category_name) VALUES ('기타');
 INSERT INTO admin(admin_account,admin_name,admin_password) VALUES ('hssarah','이한슬','qwer1234');
 INSERT INTO admin(admin_account,admin_name,admin_password) VALUES ('arock1998','최아록','qwer1234');
 
-INSERT INTO user(user_nickname,user_phone_num,user_birth,user_gender,marketing_agree_yn) VALUES ('우영우', '010-1511-2662', '1995-04-02', 'F', 1);
-INSERT INTO user(user_nickname,user_phone_num,user_birth,user_gender,marketing_agree_yn) VALUES ('홍길동', '010-1111-2222', '1900-01-01', 'M', 1);
+INSERT INTO user(created_at,user_nickname,user_phone_num,user_birth,user_gender,marketing_agree_yn) VALUES ('2022-03-10T02:29:45','우영우', '010-1511-2662', '1995-04-02', 'F', 1);
+INSERT INTO user(created_at,user_nickname,user_phone_num,user_birth,user_gender,marketing_agree_yn) VALUES ('2020-09-18T02:29:45','홍길동', '010-1111-2222', '1900-01-01', 'M', 1);
 
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('포인트나인 강남점','02-1919-1919',1, POINT(127.127730, 38.439801),"http://www.pointnine.com","서울시 서초구 서초3동 어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('더클루 강남점','02-2323-1111',1, POINT(127.127730, 38.439801),"http://www.theclue.com","서울시 어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('룰루랄라라','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.lululalala.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
+INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('방탈출고고싱','031-2020-1124',12,POINT(127.127730, 38.439801),"http://www.gogosing.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('ㅂㅐㄱ설공주','02-6653-1624',5, POINT(127.127730, 38.439801),"http://www.snowwhite.com","어쩌구 주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
 INSERT INTO cafe(cafe_name,cafe_phone_num,location_id,geography,website,address,image_url) VALUES ('사과 맛있어욤','031-2020-1124',12, POINT(127.127730, 38.439801),"http://www.appleapple.com","주소주소입니다주소","https://storage.cloud.google.com/ask_watson/test/front/IMG_9823.jpg");
@@ -76,6 +97,8 @@ INSERT INTO faq(title,content) VALUES('자주묻는질문3','자주자주 묻는
 INSERT INTO faq(title,content) VALUES('자주묻는질문4','자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 ');
 INSERT INTO faq(title,content) VALUES('자주묻는질문5','자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 ');
 INSERT INTO faq(title,content) VALUES('자주묻는질문ㅇ6','자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 자주자주 묻는 질문들 ');
+
+INSERT INTO escape_complete(user_id,theme_id,escape_complete_dt) VALUES(1,1,'2022-03-04');
 
 INSERT INTO review(user_id,difficulty,time_taken,used_hint_num,rating,device_ratio,activity,content,theme_id) VALUES(1,3,45,7,2.3,4,4,"리뷰예시입니다ㅏㅏㅏㅏㅏㅏ",1);
 INSERT INTO review(user_id,difficulty,time_taken,used_hint_num,rating,device_ratio,activity,content,theme_id) VALUES(2,3,45,7,2.3,4,4,"리뷰예시~~~~입니다ㅏㅏㅏㅏㅏㅏ",2);


### PR DESCRIPTION
## 어떤 변경사항을 반영한 pr인가요?
방탈출 카페, 테마 객체 등록 api

## 리뷰 시 참고할 내용은 무엇인가요?
급한 수정사항이 있어서 먼저 pr 드립니다 ㅠㅠ
프런트에서 구글 클라우드 스토리지에 저장되는 이미지 파일의 중복을 피하기 위해 스토리지에 저장될 때 '{카페 or 테마의 Id}_이미지파일명.png'이런식으로 저장되게 프런트를 수정했는데, 이를 위해 객체등록 api를 생성했습니다.
프로세스가 다음과 같습니다
1. 프런트에서 카페추가/테마추가 버튼 클릭 시 -> 백엔드에서 카페/테마 객체가 등록되면서 id값을 받아옴
2. 받아온 Id값을 프런트에서 새카페/새테마 등록팝업으로 넘겨줌
3. 프런트에서 새카페/새테마 정보 입력후 해당 Id 값으로 PutRequest
4. 등록 완료

 다른 의견 있으시면 얘기해주세요! 추가로 바뀐 컬럼 길이들 헷갈릴 것 같아서 코드에서도 변경해두었습니다!